### PR TITLE
Make rabbit messages delivery persistent

### DIFF
--- a/src/Bonami/HoneyBunny/Publisher.php
+++ b/src/Bonami/HoneyBunny/Publisher.php
@@ -53,7 +53,10 @@ class Publisher {
 	 */
 	public function publish($message) {
 		$this->initialize();
-		$this->channel->publish($message, [], $this->exchangeName, $this->queue);
+		$headers = [
+			'delivery_mode' => 2, // Persistent delivery
+		];
+		$this->channel->publish($message, $headers, $this->exchangeName, $this->queue);
 	}
 
 	/** @return void */


### PR DESCRIPTION
Well, yeah, durable flag on queue means that queue itself persist restart of rabbit, not the messeges in the queue. To make them persistent, special header is needed to be set.
**It's cherry pick from Bonami\Rabbit.**

jde o tento commit z bonami od jt 1c181069238d66a6a71842dd0382be41fff0a23b